### PR TITLE
fix(k8s): add securityContext to prevent privilege escalation

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         - name: web
           image: devops-chat:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
## Summary
- Add `securityContext` with `allowPrivilegeEscalation: false` to container spec in Kubernetes deployment
- Addresses Semgrep security rule for preventing setuid/setgid binary privilege escalation attacks
- Enhances pod security by limiting privileged processes within containers

## Changes Made
- Updated `k8s/deployment.yaml` to include security context configuration
- Added `allowPrivilegeEscalation: false` parameter to prevent privilege escalation

## Security Impact
This change mitigates the risk of privilege escalation attacks by preventing containers from running privileged processes that could exploit setuid/setgid binaries. This is a recommended security best practice for Kubernetes deployments.

## Test Plan
- [x] Verify deployment configuration is valid
- [x] Confirm security context is properly applied
- [ ] Deploy to test environment and validate functionality

🤖 Generated with [Claude Code](https://claude.ai/code)